### PR TITLE
Prevent duplicate error logging.

### DIFF
--- a/sentry.py
+++ b/sentry.py
@@ -1,4 +1,5 @@
 import sentry_sdk
+from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.utils import event_from_exception, exc_info_from_error
 
 
@@ -12,6 +13,10 @@ class ErrorHandler(object):
                 "If you set USE_CUSTOM_ERROR_HANDLING to True, and you are using thumbor.error_handlers.sentry, " +
                 "then you must specify the Sentry DSN using the SENTRY_DSN_URL configuration."
             )
+
+        # Logging integration will create duplicates if below not ignored
+        ignore_logger('thumbor')
+        ignore_logger('tornado.access')
 
         sentry_sdk.init(
             dsn=dsn,


### PR DESCRIPTION
This prevents duplicates being logged by sentry due to sentry sdk default integrations.